### PR TITLE
feat: add health endpoint, structured logging and Prometheus metrics

### DIFF
--- a/Documentacion/health-controller.md
+++ b/Documentacion/health-controller.md
@@ -1,0 +1,184 @@
+# Health Controller — Documentación
+
+## Descripción general
+
+Módulo de monitoreo del estado del sistema para el portal Hachiko.
+Expone dos endpoints REST bajo `/api/health` que permiten verificar si los componentes
+críticos de la aplicación están funcionando correctamente.
+
+---
+
+## Archivos creados
+
+### DTOs
+
+| Archivo | Paquete |
+|---|---|
+| `ComponentStatus.java` | `com.hachiko.portal.dto.health` |
+| `HealthResponse.java` | `com.hachiko.portal.dto.health` |
+| `HealthDetailResponse.java` | `com.hachiko.portal.dto.health` |
+
+### Servicio
+
+| Archivo | Paquete |
+|---|---|
+| `IHealthService.java` | `com.hachiko.portal.service` |
+| `HealthServiceImpl.java` | `com.hachiko.portal.service.impl` |
+
+### Controlador
+
+| Archivo | Paquete |
+|---|---|
+| `HealthController.java` | `com.hachiko.portal.controller` |
+
+### Archivo modificado
+
+| Archivo | Cambio |
+|---|---|
+| `SecurityConfig.java` | Se agregaron las reglas de acceso para `/api/health` y `/api/health/details` |
+
+---
+
+## Endpoints
+
+Base URL: `http://localhost:8080`
+
+---
+
+### GET /api/health — Público
+
+Verifica el estado general del sistema consultando únicamente la base de datos.
+No requiere token de autenticación.
+
+Retorna **HTTP 200** si el sistema está operativo y **HTTP 503** si hay un fallo crítico.
+
+**Respuesta 200 — Sistema operativo:**
+```json
+{
+  "status": "UP",
+  "timestamp": "2026-04-30T15:00:00Z"
+}
+```
+
+**Respuesta 503 — Fallo crítico:**
+```json
+{
+  "status": "DOWN",
+  "timestamp": "2026-04-30T15:00:00Z"
+}
+```
+
+---
+
+### GET /api/health/details — Requiere JWT + rol ADMIN
+
+Verifica el estado detallado de cada componente del sistema.
+Requiere token JWT de un usuario con rol `ADMIN`.
+
+Retorna **HTTP 200** si todos los componentes están UP y **HTTP 503** si alguno falla.
+
+**Header requerido:**
+```
+Authorization: Bearer <jwt_token>
+```
+
+**Respuesta 200:**
+```json
+{
+  "status": "UP",
+  "timestamp": "2026-04-30T15:00:00Z",
+  "version": "0.0.1-SNAPSHOT",
+  "uptimeSeconds": 3600,
+  "components": [
+    {
+      "name": "database",
+      "status": "UP",
+      "message": "Conexión activa",
+      "responseTimeMs": 14
+    },
+    {
+      "name": "tokenBlacklist",
+      "status": "UP",
+      "message": "Servicio activo",
+      "responseTimeMs": 1
+    },
+    {
+      "name": "emailProvider",
+      "status": "UP",
+      "message": "Modo stub activo",
+      "responseTimeMs": 0
+    }
+  ]
+}
+```
+
+**Respuesta 503 — Base de datos caída:**
+```json
+{
+  "status": "DOWN",
+  "timestamp": "2026-04-30T15:00:00Z",
+  "version": "0.0.1-SNAPSHOT",
+  "uptimeSeconds": 120,
+  "components": [
+    {
+      "name": "database",
+      "status": "DOWN",
+      "message": "Error de conexión: Connection refused",
+      "responseTimeMs": 2001
+    },
+    {
+      "name": "tokenBlacklist",
+      "status": "UP",
+      "message": "Servicio activo",
+      "responseTimeMs": 1
+    },
+    {
+      "name": "emailProvider",
+      "status": "UP",
+      "message": "Modo stub activo",
+      "responseTimeMs": 0
+    }
+  ]
+}
+```
+
+---
+
+## Componentes verificados
+
+| Componente | Cómo se verifica | Crítico |
+|---|---|---|
+| `database` | Ejecuta `SELECT 1` con timeout de 2 segundos via `DataSource` | Sí — determina el status general |
+| `tokenBlacklist` | Llama `isBlacklisted()` con una sonda ficticia | Sí |
+| `emailProvider` | Lee la propiedad `email.provider` del yaml (sin llamada de red) | No |
+
+---
+
+## Reglas de acceso (SecurityConfig)
+
+```
+GET /api/health         → público (sin token)
+GET /api/health/details → requiere JWT + rol ADMIN
+```
+
+---
+
+## Lógica de status general
+
+- Si **cualquier** componente tiene `status: "DOWN"` → respuesta general `"DOWN"` + HTTP 503.
+- Si todos los componentes tienen `status: "UP"` → respuesta general `"UP"` + HTTP 200.
+
+El código HTTP 503 permite que balanceadores de carga detecten automáticamente
+cuando la aplicación no está disponible.
+
+---
+
+## Pruebas con curl
+
+```bash
+# Endpoint público
+curl http://localhost:8080/api/health
+
+# Endpoint admin (reemplazar <token> con un JWT de ADMIN)
+curl -H "Authorization: Bearer <token>" http://localhost:8080/api/health/details
+```

--- a/Documentacion/logging-y-prometheus.md
+++ b/Documentacion/logging-y-prometheus.md
@@ -1,0 +1,242 @@
+# Logging Estructurado y Prometheus — Hachiko Portal
+
+## Contexto
+
+El backend de Hachiko Portal (Spring Boot 4.0.5, Java 21) no contaba con logging estructurado ni con métricas expuestas. Esta documentación describe la configuración básica añadida para cubrir:
+
+- **Logging estructurado** con Logback + `logstash-logback-encoder` (equivalente a Winston en Node.js)
+- **Métricas HTTP, JVM y pool de BD** expuestas en `/actuator/prometheus` via Micrometer
+- **Trazabilidad por request** mediante `correlationId` en MDC y header de respuesta
+
+---
+
+## Archivos modificados
+
+### `pom.xml`
+
+Se añadieron tres dependencias al bloque `<dependencies>`:
+
+```xml
+<!-- Logging estructurado JSON -->
+<dependency>
+  <groupId>net.logstash.logback</groupId>
+  <artifactId>logstash-logback-encoder</artifactId>
+  <version>8.0</version>
+</dependency>
+
+<!-- Actuator: expone endpoints de métricas y salud -->
+<dependency>
+  <groupId>org.springframework.boot</groupId>
+  <artifactId>spring-boot-starter-actuator</artifactId>
+</dependency>
+
+<!-- Prometheus registry via Micrometer -->
+<dependency>
+  <groupId>io.micrometer</groupId>
+  <artifactId>micrometer-registry-prometheus</artifactId>
+</dependency>
+```
+
+---
+
+### `src/main/resources/application.yaml`
+
+Se añadieron dos secciones nuevas:
+
+```yaml
+# ─── Actuator + Prometheus ────────────────────────────────────────────────────
+management:
+  endpoints:
+    web:
+      base-path: /actuator
+      exposure:
+        include: health, prometheus, info
+  endpoint:
+    health:
+      show-details: never
+  metrics:
+    tags:
+      application: ${spring.application.name}
+      env: ${spring.profiles.active:default}
+
+# ─── Logging ──────────────────────────────────────────────────────────────────
+logging:
+  level:
+    root: INFO
+    "[com.hachiko.portal]": DEBUG
+```
+
+**Notas:**
+- `show-details: never` en el actuator health evita duplicar la lógica ya existente en `/api/health/details` (admin).
+- Los tags `application` y `env` se propagan automáticamente a todas las métricas de Micrometer.
+- El nivel `DEBUG` para `com.hachiko.portal` solo aplica en perfil `local`; en `prod` el `logback-spring.xml` lo sobreescribe a `INFO`.
+
+---
+
+### `src/main/java/com/hachiko/portal/config/SecurityConfig.java`
+
+Se añadieron tres reglas al bloque `authorizeHttpRequests`, antes de las rutas existentes:
+
+```java
+// Actuator: health público, prometheus y resto solo ADMIN
+.requestMatchers("/actuator/health").permitAll()
+.requestMatchers("/actuator/prometheus", "/actuator/**").hasRole("ADMIN")
+```
+
+**Motivo:** `/actuator/prometheus` expone datos internos de la JVM y del pool de BD; restringirlo a `ROLE_ADMIN` evita filtrar información sensible.
+
+---
+
+## Archivos creados
+
+### `src/main/resources/logback-spring.xml`
+
+Configura el formato de logs según el perfil activo de Spring:
+
+```xml
+<configuration>
+
+  <!-- Perfil local/dev: texto plano con colores -->
+  <springProfile name="local,default">
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+      <encoder>
+        <pattern>%d{HH:mm:ss.SSS} [%thread] %highlight(%-5level) %cyan(%logger{36}) - %msg%n</pattern>
+      </encoder>
+    </appender>
+    <logger name="com.hachiko.portal" level="DEBUG"/>
+    <root level="INFO"><appender-ref ref="CONSOLE"/></root>
+  </springProfile>
+
+  <!-- Perfil prod: JSON estructurado (ingestable por Loki / ELK) -->
+  <springProfile name="prod">
+    <appender name="JSON_CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+      <encoder class="net.logstash.logback.encoder.LogstashEncoder">
+        <includeContext>false</includeContext>
+        <timestampPattern>yyyy-MM-dd'T'HH:mm:ss.SSSZZ</timestampPattern>
+      </encoder>
+    </appender>
+    <logger name="com.hachiko.portal" level="INFO"/>
+    <root level="INFO"><appender-ref ref="JSON_CONSOLE"/></root>
+  </springProfile>
+
+</configuration>
+```
+
+| Perfil | Formato | Nivel app |
+|---|---|---|
+| `local` / `default` | Texto plano con colores | DEBUG |
+| `prod` | JSON estructurado | INFO |
+
+El `correlationId` cargado en MDC por `RequestLoggingFilter` se incluye automáticamente en cada línea JSON cuando se usa `LogstashEncoder`.
+
+---
+
+### `src/main/java/com/hachiko/portal/filter/RequestLoggingFilter.java`
+
+`OncePerRequestFilter` que se ejecuta con máxima prioridad en cada request:
+
+```java
+@Component
+@Order(Ordered.HIGHEST_PRECEDENCE)
+public class RequestLoggingFilter extends OncePerRequestFilter {
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+
+        String correlationId = UUID.randomUUID().toString();
+        long startTime = System.currentTimeMillis();
+
+        MDC.put("correlationId", correlationId);
+        response.setHeader("X-Correlation-Id", correlationId);
+
+        try {
+            filterChain.doFilter(request, response);
+        } finally {
+            long duration = System.currentTimeMillis() - startTime;
+            log.info("method={} uri={} status={} duration={}ms correlationId={}",
+                    request.getMethod(), request.getRequestURI(),
+                    response.getStatus(), duration, correlationId);
+            MDC.clear();
+        }
+    }
+}
+```
+
+**Responsabilidades:**
+- Genera un `UUID` único por request como `correlationId`.
+- Lo inyecta en el MDC de SLF4J para que aparezca en todos los logs de esa thread.
+- Lo devuelve al cliente como header `X-Correlation-Id`.
+- Emite una línea de log con método, URI, status HTTP y duración al finalizar el request.
+- Limpia el MDC con `MDC.clear()` al terminar para evitar filtraciones entre requests.
+
+---
+
+### `src/main/java/com/hachiko/portal/config/MetricsConfig.java`
+
+Punto central para registrar métricas custom futuras. Actualmente añade el tag `app` a todas las métricas:
+
+```java
+@Configuration
+public class MetricsConfig {
+
+    private final MeterRegistry meterRegistry;
+
+    @Value("${spring.application.name:hachiko-portal}")
+    private String appName;
+
+    public MetricsConfig(MeterRegistry meterRegistry) {
+        this.meterRegistry = meterRegistry;
+    }
+
+    @PostConstruct
+    void init() {
+        meterRegistry.config().commonTags("app", appName);
+    }
+}
+```
+
+**Nota:** `MeterRegistryCustomizer` fue eliminado en Spring Boot 4.x. La configuración de tags programática se hace directamente sobre el bean `MeterRegistry` via `@PostConstruct`. Los tags `application` y `env` se configuran además desde `application.yaml` bajo `management.metrics.tags`.
+
+---
+
+## Separación de responsabilidades
+
+| Capa | Archivo | Responsabilidad |
+|---|---|---|
+| Filter | `RequestLoggingFilter` | Log por request + correlationId en MDC |
+| Config / XML | `logback-spring.xml` | Formato de salida de logs por perfil |
+| Config / Java | `MetricsConfig` | Tags globales y métricas custom futuras |
+| Config / Java | `SecurityConfig` | Control de acceso a endpoints de actuator |
+| Config / YAML | `application.yaml` | Exposición de endpoints y tags automáticos |
+
+---
+
+## Verificación
+
+### Health
+```
+GET http://localhost:8080/api/health
+→ 200 {"status":"UP"}
+→ Header en respuesta: X-Correlation-Id: <uuid>
+```
+
+### Logging
+En la consola de la app, tras cualquier request, aparece:
+```
+HH:mm:ss.SSS [thread] INFO  c.h.p.filter.RequestLoggingFilter - method=GET uri=/api/health status=200 duration=5ms correlationId=<uuid>
+```
+
+### Prometheus
+```
+GET http://localhost:8080/actuator/prometheus
+Authorization: Bearer <token-ADMIN>
+→ 200 texto con métricas
+→ Sin token o sin rol ADMIN → 403
+```
+
+Para activar logs JSON:
+```
+./mvnw spring-boot:run -Dspring-boot.run.profiles=prod
+```

--- a/pom.xml
+++ b/pom.xml
@@ -93,6 +93,25 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+
+		<!-- Logging estructurado JSON (equivalente a Winston en Node.js) -->
+		<dependency>
+			<groupId>net.logstash.logback</groupId>
+			<artifactId>logstash-logback-encoder</artifactId>
+			<version>8.0</version>
+		</dependency>
+
+		<!-- Actuator: health checks + métricas -->
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-actuator</artifactId>
+		</dependency>
+
+		<!-- Prometheus registry via Micrometer -->
+		<dependency>
+			<groupId>io.micrometer</groupId>
+			<artifactId>micrometer-registry-prometheus</artifactId>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/com/hachiko/portal/config/MetricsConfig.java
+++ b/src/main/java/com/hachiko/portal/config/MetricsConfig.java
@@ -1,0 +1,29 @@
+package com.hachiko.portal.config;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import jakarta.annotation.PostConstruct;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Punto central para registrar métricas custom (Counters, Timers, Gauges).
+ * Los tags comunes (application, env) se configuran en application.yaml
+ * bajo management.metrics.tags para no duplicar lógica aquí.
+ */
+@Configuration
+public class MetricsConfig {
+
+    private final MeterRegistry meterRegistry;
+
+    @Value("${spring.application.name:hachiko-portal}")
+    private String appName;
+
+    public MetricsConfig(MeterRegistry meterRegistry) {
+        this.meterRegistry = meterRegistry;
+    }
+
+    @PostConstruct
+    void init() {
+        meterRegistry.config().commonTags("app", appName);
+    }
+}

--- a/src/main/java/com/hachiko/portal/config/SecurityConfig.java
+++ b/src/main/java/com/hachiko/portal/config/SecurityConfig.java
@@ -59,6 +59,9 @@ public class SecurityConfig {
             .sessionManagement(session ->
                     session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
             .authorizeHttpRequests(auth -> auth
+                // Actuator: health público, prometheus y resto solo ADMIN
+                .requestMatchers("/actuator/health").permitAll()
+                .requestMatchers("/actuator/prometheus", "/actuator/**").hasRole("ADMIN")
                 // Rutas públicas de autenticación
                 .requestMatchers(HttpMethod.POST, "/api/auth/login").permitAll()
                 .requestMatchers(HttpMethod.POST, "/api/auth/register").permitAll()
@@ -66,6 +69,10 @@ public class SecurityConfig {
                 .requestMatchers(HttpMethod.POST, "/api/auth/reset-password").permitAll()
                 // Datos de referencia (catálogos públicos)
                 .requestMatchers(HttpMethod.GET, "/api/referencia/**").permitAll()
+                // Health check público (estado general)
+                .requestMatchers(HttpMethod.GET, "/api/health").permitAll()
+                // Health detallado solo para administradores
+                .requestMatchers(HttpMethod.GET, "/api/health/details").hasRole("ADMIN")
                 // Solo administradores
                 .requestMatchers("/api/admin/**").hasRole("ADMIN")
                 // Todo lo demás requiere autenticación

--- a/src/main/java/com/hachiko/portal/controller/HealthController.java
+++ b/src/main/java/com/hachiko/portal/controller/HealthController.java
@@ -1,0 +1,60 @@
+package com.hachiko.portal.controller;
+
+import com.hachiko.portal.dto.health.HealthDetailResponse;
+import com.hachiko.portal.dto.health.HealthResponse;
+import com.hachiko.portal.service.IHealthService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Controlador REST para monitoreo del estado del sistema.
+ *
+ * Rutas:
+ *   GET /api/health         → público — estado general (UP / DOWN)
+ *   GET /api/health/details → solo ADMIN — estado por componente
+ *
+ * Retorna HTTP 200 cuando el sistema está UP y HTTP 503 cuando está DOWN,
+ * para que balanceadores de carga puedan interpretar el estado automáticamente.
+ */
+@RestController
+@RequestMapping("/api/health")
+public class HealthController {
+
+    private final IHealthService healthService;
+
+    public HealthController(IHealthService healthService) {
+        this.healthService = healthService;
+    }
+
+    /**
+     * Estado general del sistema. Público, sin token.
+     *
+     * GET /api/health
+     */
+    @GetMapping
+    public ResponseEntity<HealthResponse> health() {
+        HealthResponse response = healthService.getBasicHealth();
+        HttpStatus httpStatus = "UP".equals(response.getStatus())
+                ? HttpStatus.OK
+                : HttpStatus.SERVICE_UNAVAILABLE;
+        return ResponseEntity.status(httpStatus).body(response);
+    }
+
+    /**
+     * Estado detallado por componente. Requiere rol ADMIN.
+     * La autorización se controla en SecurityConfig (.hasRole("ADMIN")).
+     *
+     * GET /api/health/details
+     */
+    @GetMapping("/details")
+    public ResponseEntity<HealthDetailResponse> details() {
+        HealthDetailResponse response = healthService.getDetailedHealth();
+        HttpStatus httpStatus = "UP".equals(response.getStatus())
+                ? HttpStatus.OK
+                : HttpStatus.SERVICE_UNAVAILABLE;
+        return ResponseEntity.status(httpStatus).body(response);
+    }
+}

--- a/src/main/java/com/hachiko/portal/dto/health/ComponentStatus.java
+++ b/src/main/java/com/hachiko/portal/dto/health/ComponentStatus.java
@@ -1,0 +1,23 @@
+package com.hachiko.portal.dto.health;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * Estado de un componente individual del sistema (base de datos, JWT, email, etc.).
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ComponentStatus {
+
+    private String name;
+    private String status;
+    private String message;
+    private long responseTimeMs;
+}

--- a/src/main/java/com/hachiko/portal/dto/health/HealthDetailResponse.java
+++ b/src/main/java/com/hachiko/portal/dto/health/HealthDetailResponse.java
@@ -1,0 +1,28 @@
+package com.hachiko.portal.dto.health;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.Instant;
+import java.util.List;
+
+/**
+ * Respuesta del endpoint protegido GET /api/health/details (solo ADMIN).
+ * Incluye el estado individual de cada componente del sistema.
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class HealthDetailResponse {
+
+    private String status;
+    private Instant timestamp;
+    private String version;
+    private long uptimeSeconds;
+    private List<ComponentStatus> components;
+}

--- a/src/main/java/com/hachiko/portal/dto/health/HealthResponse.java
+++ b/src/main/java/com/hachiko/portal/dto/health/HealthResponse.java
@@ -1,0 +1,25 @@
+package com.hachiko.portal.dto.health;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.Instant;
+
+/**
+ * Respuesta del endpoint público GET /api/health.
+ * Solo expone el estado general del sistema.
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class HealthResponse {
+
+    /** "UP" si el sistema está operativo, "DOWN" si hay un fallo crítico. */
+    private String status;
+    private Instant timestamp;
+}

--- a/src/main/java/com/hachiko/portal/filter/RequestLoggingFilter.java
+++ b/src/main/java/com/hachiko/portal/filter/RequestLoggingFilter.java
@@ -1,0 +1,50 @@
+package com.hachiko.portal.filter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.UUID;
+
+@Component
+@Order(Ordered.HIGHEST_PRECEDENCE)
+public class RequestLoggingFilter extends OncePerRequestFilter {
+
+    private static final Logger log = LoggerFactory.getLogger(RequestLoggingFilter.class);
+    private static final String CORRELATION_ID_HEADER = "X-Correlation-Id";
+    private static final String MDC_CORRELATION_KEY = "correlationId";
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+
+        String correlationId = UUID.randomUUID().toString();
+        long startTime = System.currentTimeMillis();
+
+        MDC.put(MDC_CORRELATION_KEY, correlationId);
+        response.setHeader(CORRELATION_ID_HEADER, correlationId);
+
+        try {
+            filterChain.doFilter(request, response);
+        } finally {
+            long duration = System.currentTimeMillis() - startTime;
+            log.info("method={} uri={} status={} duration={}ms correlationId={}",
+                    request.getMethod(),
+                    request.getRequestURI(),
+                    response.getStatus(),
+                    duration,
+                    correlationId);
+            MDC.clear();
+        }
+    }
+}

--- a/src/main/java/com/hachiko/portal/service/IHealthService.java
+++ b/src/main/java/com/hachiko/portal/service/IHealthService.java
@@ -1,0 +1,29 @@
+package com.hachiko.portal.service;
+
+import com.hachiko.portal.dto.health.HealthDetailResponse;
+import com.hachiko.portal.dto.health.HealthResponse;
+
+/**
+ * Contrato para los checks de salud del sistema.
+ *
+ * Principio DIP: HealthController depende de esta interfaz, no de la implementación.
+ * Principio SRP: responsabilidad única — verificar disponibilidad de componentes.
+ */
+public interface IHealthService {
+
+    /**
+     * Estado general del sistema (solo base de datos).
+     * Usado por el endpoint público GET /api/health.
+     *
+     * @return HealthResponse con status UP o DOWN y timestamp actual
+     */
+    HealthResponse getBasicHealth();
+
+    /**
+     * Estado detallado por componente: base de datos, token blacklist y email provider.
+     * Usado por el endpoint protegido GET /api/health/details (solo ADMIN).
+     *
+     * @return HealthDetailResponse con status, versión, uptime y lista de componentes
+     */
+    HealthDetailResponse getDetailedHealth();
+}

--- a/src/main/java/com/hachiko/portal/service/impl/HealthServiceImpl.java
+++ b/src/main/java/com/hachiko/portal/service/impl/HealthServiceImpl.java
@@ -1,0 +1,137 @@
+package com.hachiko.portal.service.impl;
+
+import com.hachiko.portal.dto.health.ComponentStatus;
+import com.hachiko.portal.dto.health.HealthDetailResponse;
+import com.hachiko.portal.dto.health.HealthResponse;
+import com.hachiko.portal.service.IHealthService;
+import com.hachiko.portal.service.ITokenBlacklistService;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import javax.sql.DataSource;
+import java.lang.management.ManagementFactory;
+import java.sql.Connection;
+import java.sql.Statement;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Implementación del servicio de health check.
+ *
+ * Verifica tres componentes:
+ *  - database       : ejecuta SELECT 1 con timeout de 2 segundos
+ *  - tokenBlacklist : llama isBlacklisted con una sonda ficticia
+ *  - emailProvider  : lee la propiedad email.provider (no hace red)
+ *
+ * Si la base de datos está DOWN, el status general es DOWN.
+ * Los demás componentes son informativos y no afectan el status general.
+ */
+@Service
+public class HealthServiceImpl implements IHealthService {
+
+    private static final String STATUS_UP   = "UP";
+    private static final String STATUS_DOWN = "DOWN";
+
+    private final DataSource dataSource;
+    private final ITokenBlacklistService tokenBlacklistService;
+    private final String emailProvider;
+    private final String appVersion;
+
+    public HealthServiceImpl(DataSource dataSource,
+                             ITokenBlacklistService tokenBlacklistService,
+                             @Value("${email.provider}") String emailProvider,
+                             @Value("${app.version:0.0.1-SNAPSHOT}") String appVersion) {
+        this.dataSource            = dataSource;
+        this.tokenBlacklistService = tokenBlacklistService;
+        this.emailProvider         = emailProvider;
+        this.appVersion            = appVersion;
+    }
+
+    @Override
+    public HealthResponse getBasicHealth() {
+        ComponentStatus db = checkDatabase();
+        String status = STATUS_DOWN.equals(db.getStatus()) ? STATUS_DOWN : STATUS_UP;
+        return HealthResponse.builder()
+                .status(status)
+                .timestamp(Instant.now())
+                .build();
+    }
+
+    @Override
+    public HealthDetailResponse getDetailedHealth() {
+        List<ComponentStatus> components = new ArrayList<>();
+        components.add(checkDatabase());
+        components.add(checkTokenBlacklist());
+        components.add(checkEmailProvider());
+
+        boolean anyDown = components.stream()
+                .anyMatch(c -> STATUS_DOWN.equals(c.getStatus()));
+        String status = anyDown ? STATUS_DOWN : STATUS_UP;
+
+        long uptimeSeconds = ManagementFactory.getRuntimeMXBean().getUptime() / 1000;
+
+        return HealthDetailResponse.builder()
+                .status(status)
+                .timestamp(Instant.now())
+                .version(appVersion)
+                .uptimeSeconds(uptimeSeconds)
+                .components(components)
+                .build();
+    }
+
+    private ComponentStatus checkDatabase() {
+        long start = System.currentTimeMillis();
+        try (Connection conn = dataSource.getConnection();
+             Statement stmt  = conn.createStatement()) {
+            stmt.setQueryTimeout(2);
+            stmt.execute("SELECT 1");
+            return ComponentStatus.builder()
+                    .name("database")
+                    .status(STATUS_UP)
+                    .message("Conexión activa")
+                    .responseTimeMs(System.currentTimeMillis() - start)
+                    .build();
+        } catch (Exception e) {
+            return ComponentStatus.builder()
+                    .name("database")
+                    .status(STATUS_DOWN)
+                    .message("Error de conexión: " + e.getMessage())
+                    .responseTimeMs(System.currentTimeMillis() - start)
+                    .build();
+        }
+    }
+
+    private ComponentStatus checkTokenBlacklist() {
+        long start = System.currentTimeMillis();
+        try {
+            tokenBlacklistService.isBlacklisted("health-check-probe");
+            return ComponentStatus.builder()
+                    .name("tokenBlacklist")
+                    .status(STATUS_UP)
+                    .message("Servicio activo")
+                    .responseTimeMs(System.currentTimeMillis() - start)
+                    .build();
+        } catch (Exception e) {
+            return ComponentStatus.builder()
+                    .name("tokenBlacklist")
+                    .status(STATUS_DOWN)
+                    .message("Error: " + e.getMessage())
+                    .responseTimeMs(System.currentTimeMillis() - start)
+                    .build();
+        }
+    }
+
+    private ComponentStatus checkEmailProvider() {
+        long start = System.currentTimeMillis();
+        String message = "stub".equals(emailProvider)
+                ? "Modo stub activo"
+                : "Proveedor: " + emailProvider;
+        return ComponentStatus.builder()
+                .name("emailProvider")
+                .status(STATUS_UP)
+                .message(message)
+                .responseTimeMs(System.currentTimeMillis() - start)
+                .build();
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -28,6 +28,27 @@ jwt:
 cors:
   allowed-origins: ${CORS_ALLOWED_ORIGINS:http://localhost:3000,http://localhost:5173,http://localhost:5174,http://localhost:8080}
 
+# ─── Actuator + Prometheus ────────────────────────────────────────────────────
+management:
+  endpoints:
+    web:
+      base-path: /actuator
+      exposure:
+        include: health, prometheus, info
+  endpoint:
+    health:
+      show-details: never
+  metrics:
+    tags:
+      application: ${spring.application.name}
+      env: ${spring.profiles.active:default}
+
+# ─── Logging ──────────────────────────────────────────────────────────────────
+logging:
+  level:
+    root: INFO
+    "[com.hachiko.portal]": DEBUG
+
 # ─── Email ────────────────────────────────────────────────────────────────────
 # provider: stub   → solo loguea (por defecto, sin configuración extra)
 # provider: resend → envía emails reales via Resend API

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+    <!-- ── Perfil local / dev: texto plano con colores ───────────────────── -->
+    <springProfile name="local,default">
+        <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+            <encoder>
+                <pattern>%d{HH:mm:ss.SSS} [%thread] %highlight(%-5level) %cyan(%logger{36}) - %msg%n</pattern>
+            </encoder>
+        </appender>
+
+        <logger name="com.hachiko.portal" level="DEBUG"/>
+        <root level="INFO">
+            <appender-ref ref="CONSOLE"/>
+        </root>
+    </springProfile>
+
+    <!-- ── Perfil prod: JSON estructurado (ingestable por Loki / ELK) ────── -->
+    <springProfile name="prod">
+        <appender name="JSON_CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+            <encoder class="net.logstash.logback.encoder.LogstashEncoder">
+                <includeContext>false</includeContext>
+                <timestampPattern>yyyy-MM-dd'T'HH:mm:ss.SSSZZ</timestampPattern>
+                <!-- El correlationId se incluye automáticamente desde MDC -->
+            </encoder>
+        </appender>
+
+        <logger name="com.hachiko.portal" level="INFO"/>
+        <root level="INFO">
+            <appender-ref ref="JSON_CONSOLE"/>
+        </root>
+    </springProfile>
+
+</configuration>


### PR DESCRIPTION
- HealthController with GET /api/health (public) and GET /api/health/details (ADMIN)
- IHealthService + HealthServiceImpl with component status checks
- DTOs: HealthResponse, HealthDetailResponse, ComponentStatus
- Logback JSON structured logging via logstash-logback-encoder (prod profile)
- RequestLoggingFilter: correlationId in MDC + X-Correlation-Id response header
- MetricsConfig: Micrometer common tags via @PostConstruct
- Prometheus metrics exposed at /actuator/prometheus (ADMIN only)
- SecurityConfig updated to protect /actuator/** endpoints
- application.yaml: management endpoints + logging levels configured
- Documentacion: health-controller.md and logging-y-prometheus.md